### PR TITLE
Update https check for new version of nextjs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ const middleware = ({
 }: Params) => (req: NextRequest, ev: NextFetchEvent) => {
     const currentEnv = process.env.NODE_ENV as Environment;
 
-    if (environments.includes(currentEnv) && req.headers.get("x-forwarded-proto") !== "https") {
+    if (environments.includes(currentEnv) && !req.headers?.get("x-forwarded-proto")?.includes("https") {
         const hostname = req.headers.get('host') || req.nextUrl.hostname;
         return NextResponse.redirect(`https://${hostname}${req.nextUrl.pathname}`, status);
     }


### PR DESCRIPTION
old code produces ERR_TOO_MANY_REDIRECTS on heroku

Nextjs v13.4.7
`req.headers.get('x-forwarded-proto')` now returns "http,http" or "https,http" rather than "http" or "https"

see: https://github.com/vercel/next.js/discussions/51970