### PR TITLE
Add logging about the environments and current environment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "next-ssl-redirect-middleware",
-  "version": "0.1.4",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "next-ssl-redirect-middleware",
-      "version": "0.1.4",
+      "version": "0.1.6",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^16.11.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-ssl-redirect-middleware",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Nextjs Middleware to redirect http to https",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ const middleware = ({
     status = 301
 }: Params) => (req: NextRequest, ev: NextFetchEvent) => {
     const currentEnv = process.env.NODE_ENV as Environment;
-
+    console.log('environments', environments, 'currentEnv', currentEnv);
     if (environments.includes(currentEnv) && !req.headers?.get("x-forwarded-proto")?.includes("https")) {
         const hostname = req.headers.get('host') || req.nextUrl.hostname;
         return NextResponse.redirect(`https://${hostname}${req.nextUrl.pathname}`, status);


### PR DESCRIPTION
I've been struggling with Cypress tests in CI - this middleware seems to be running when Cypress runs, and this middleware is forwarding it to https even when running in localhost, which is confusing since the NODE_ENV shouldn't be set to production in that case.  Going to check it out.